### PR TITLE
Add show_schedules option,  Dutch translation and Fix CSS HA compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ Thumbs.db
 .github/instructions/*
 target
 .npmrc
+
+deploy.sh

--- a/src/components/edit-dialog.ts
+++ b/src/components/edit-dialog.ts
@@ -87,6 +87,7 @@ export class MealEditDialog extends LitElement {
     label {
       font-weight: 500;
       font-size: 0.95em;
+      color: var(--primary-text-color);
     }
     input[type='time'],
     input[type='number'] {
@@ -96,6 +97,13 @@ export class MealEditDialog extends LitElement {
       font-size: 1em;
       width: 100%;
       box-sizing: border-box;
+      background-color: var(--card-background-color);
+      color: var(--primary-text-color);
+      outline: none;
+    }
+    input[type='time']:focus,
+    input[type='number']:focus {
+      border-color: var(--primary-color);
     }
     .edit-mode .days-row {
       justify-content: center;

--- a/src/components/meal-card.ts
+++ b/src/components/meal-card.ts
@@ -16,11 +16,15 @@ export class MealCard extends LitElement {
 
   static styles = css`
     .meal-card {
-      background: var(--card-background-color, #fff);
-      border-radius: 6px;
+      background: var(
+        --meal-card-background,
+        var(--card-background-color, #fff)
+      );
+      border-radius: var(--meal-card-border-radius, 6px);
       margin-bottom: 6px;
-      border: 1px solid var(--divider-color, rgba(0, 0, 0, 0.12));
-      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+      border: 1px solid
+        var(--meal-card-border-color, var(--divider-color, rgba(0, 0, 0, 0.12)));
+      box-shadow: var(--meal-card-box-shadow, 0 1px 3px rgba(0, 0, 0, 0.08));
     }
     .meal-card-header {
       display: flex;
@@ -112,8 +116,12 @@ export class MealCard extends LitElement {
     }
     .meal-card-details {
       padding: 0 10px 8px 10px;
-      border-top: 1px solid var(--divider-color, #e0e0e0);
-      background: var(--secondary-background-color, #f5f5f5);
+      border-top: 1px solid
+        var(--meal-card-border-color, var(--divider-color, #e0e0e0));
+      background: var(
+        --meal-card-details-background,
+        var(--secondary-background-color, #f5f5f5)
+      );
     }
     .meal-card-row {
       display: flex;
@@ -143,7 +151,6 @@ export class MealCard extends LitElement {
       --mdc-theme-primary: var(--error-color, #db4437);
     }
   `;
-
   private toggleExpand() {
     const wasExpanded = this.expanded;
     this.expanded = !this.expanded;

--- a/src/components/schedule-view.ts
+++ b/src/components/schedule-view.ts
@@ -1,8 +1,3 @@
-/**
- * ScheduleView component for managing meal schedules
- * Self-contained LitElement component with internal state
- */
-
 import { LitElement, html, css } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { localize } from '../locales/localize';
@@ -16,14 +11,11 @@ import type { MealEditDialog } from './edit-dialog';
 import './meal-card';
 import './message-banner';
 
-/**
- * Schedule view component
- * Emits: 'schedule-closed' when dialog closes
- */
 @customElement('schedule-view')
 export class ScheduleView extends LitElement {
   @property({ type: Object }) mealState!: MealStateController;
   @property({ type: Object }) hass!: HomeAssistant;
+  @property({ type: Boolean }) openAddOnLoad = false;
 
   @state() private draftMeals: FeedingTime[] = [];
   @state() private editMeal: EditMealState | null = null;
@@ -34,22 +26,21 @@ export class ScheduleView extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
-    // Initialize draft from current meals (sorted by time)
     this.draftMeals = this.sortMealsByTime([...this.mealState.meals]);
 
     this.mealState.isDataAvailable().then((available) => {
       this.dataAvailable = available;
     });
 
-    // Subscribe to meals changes from MealStateController
     this.unsubscribe = this.mealState.subscribe(() => {
       this.syncMealsWithController();
     });
+
+    if (this.openAddOnLoad) {
+      this.handleOpenAdd();
+    }
   }
 
-  /**
-   * Sort meals by time (hour, then minute)
-   */
   private sortMealsByTime(meals: FeedingTime[]): FeedingTime[] {
     return [...meals].sort(
       (a, b) =>
@@ -88,9 +79,6 @@ export class ScheduleView extends LitElement {
     }
   `;
 
-  /**
-   * Reset draft to match controller's saved meals
-   */
   private syncMealsWithController(): void {
     this.draftMeals = this.sortMealsByTime([...this.mealState.meals]);
   }
@@ -100,15 +88,15 @@ export class ScheduleView extends LitElement {
       this.draftMeals.map((m, i) => (i === index ? meal : m)),
     );
   }
+
   public getMeals(): FeedingTime[] {
     return this.draftMeals;
   }
+
   public getEditMeals(): EditMealState | null {
     return this.editMeal;
   }
-  /**
-   * Unified handler for meal actions from meal-card
-   */
+
   public handleMealAction(
     action: 'update' | 'delete' | 'edit',
     index: number,
@@ -124,9 +112,6 @@ export class ScheduleView extends LitElement {
     }
   }
 
-  /**
-   * Add new meal to draft
-   */
   public addMeal(meal: FeedingTime): void {
     this.draftMeals = this.sortMealsByTime([...this.draftMeals, meal]);
   }
@@ -156,10 +141,8 @@ export class ScheduleView extends LitElement {
     const { meal, index } = e.detail;
 
     if (index !== undefined && index >= 0) {
-      // Update existing meal
       this.updateMeal(index, meal);
     } else {
-      // Add new meal
       this.addMeal(meal);
     }
 
@@ -175,9 +158,6 @@ export class ScheduleView extends LitElement {
     return !areMealsEqual(this.draftMeals, this.mealState.meals);
   }
 
-  /**
-   * Render meal form (for adding or editing)
-   */
   private renderMealForm() {
     if (this.editMeal === null) return '';
 
@@ -203,12 +183,12 @@ export class ScheduleView extends LitElement {
         <ha-button
           slot="primaryAction"
           @click=${() => {
-            const dialog =
-              this.shadowRoot?.querySelector<MealEditDialog>(
-                'meal-edit-dialog',
-              );
-            dialog?.handleSave();
-          }}
+        const dialog =
+          this.shadowRoot?.querySelector<MealEditDialog>(
+            'meal-edit-dialog',
+          );
+        dialog?.handleSave();
+      }}
         >
           ${localize('common.save')}
         </ha-button>
@@ -216,9 +196,6 @@ export class ScheduleView extends LitElement {
     `;
   }
 
-  /**
-   * Render empty state when no meals exist
-   */
   private renderEmptyState() {
     return html`
       <div class="empty-state">
@@ -233,9 +210,6 @@ export class ScheduleView extends LitElement {
     `;
   }
 
-  /**
-   * Render Add Meal button if profile allows it
-   */
   private renderAddButton() {
     if (!hasProfileField(this.mealState.profile, ProfileField.ADD)) return '';
 
@@ -250,9 +224,6 @@ export class ScheduleView extends LitElement {
     `;
   }
 
-  /**
-   * Render card-based view
-   */
   private renderCardView() {
     if (this.editMeal !== null) return '';
     if (!this.mealState.profile) return '';
@@ -266,9 +237,9 @@ export class ScheduleView extends LitElement {
       ></message-banner>
       <div class="schedule-cards">
         ${this.draftMeals.length === 0
-          ? this.renderEmptyState()
-          : this.draftMeals.map(
-              (meal, index) => html`
+        ? this.renderEmptyState()
+        : this.draftMeals.map(
+          (meal, index) => html`
                 <meal-card
                   .meal=${meal}
                   .index=${index}
@@ -277,7 +248,7 @@ export class ScheduleView extends LitElement {
                 >
                 </meal-card>
               `,
-            )}
+        )}
       </div>
       <ha-dialog-footer slot="footer">
         ${this.renderAddButton()}

--- a/src/components/schedule-view.ts
+++ b/src/components/schedule-view.ts
@@ -183,12 +183,12 @@ export class ScheduleView extends LitElement {
         <ha-button
           slot="primaryAction"
           @click=${() => {
-        const dialog =
-          this.shadowRoot?.querySelector<MealEditDialog>(
-            'meal-edit-dialog',
-          );
-        dialog?.handleSave();
-      }}
+            const dialog =
+              this.shadowRoot?.querySelector<MealEditDialog>(
+                'meal-edit-dialog',
+              );
+            dialog?.handleSave();
+          }}
         >
           ${localize('common.save')}
         </ha-button>
@@ -237,9 +237,9 @@ export class ScheduleView extends LitElement {
       ></message-banner>
       <div class="schedule-cards">
         ${this.draftMeals.length === 0
-        ? this.renderEmptyState()
-        : this.draftMeals.map(
-          (meal, index) => html`
+          ? this.renderEmptyState()
+          : this.draftMeals.map(
+              (meal, index) => html`
                 <meal-card
                   .meal=${meal}
                   .index=${index}
@@ -248,7 +248,7 @@ export class ScheduleView extends LitElement {
                 >
                 </meal-card>
               `,
-        )}
+            )}
       </div>
       <ha-dialog-footer slot="footer">
         ${this.renderAddButton()}

--- a/src/components/schedule-view.ts
+++ b/src/components/schedule-view.ts
@@ -49,7 +49,7 @@ export class ScheduleView extends LitElement {
       }
     }, 0);
   }
-  
+
   private sortMealsByTime(meals: FeedingTime[]): FeedingTime[] {
     return [...meals].sort(
       (a, b) =>

--- a/src/components/schedule-view.ts
+++ b/src/components/schedule-view.ts
@@ -36,11 +36,20 @@ export class ScheduleView extends LitElement {
       this.syncMealsWithController();
     });
 
-    if (this.openAddOnLoad) {
-      this.handleOpenAdd();
-    }
+    // Use setTimeout to ensure properties are set before checking
+    setTimeout(() => {
+      if (this.openAddOnLoad) {
+        this.handleOpenAdd();
+      } else if (this.editMealIndex !== undefined) {
+        const meal = this.mealState.meals[this.editMealIndex];
+        if (meal) {
+          this.heading = localize('schedule_view.edit_feeding_time');
+          this.editMeal = { meal, index: this.editMealIndex };
+        }
+      }
+    }, 0);
   }
-
+  
   private sortMealsByTime(meals: FeedingTime[]): FeedingTime[] {
     return [...meals].sort(
       (a, b) =>

--- a/src/config-form.ts
+++ b/src/config-form.ts
@@ -22,17 +22,12 @@ export class MealPlanCardEditor extends LitElement {
   private _getAvailableServices() {
     const services: Array<{ value: string; label: string }> = [];
     if (!this.hass?.services) return services;
-
     for (const [domain, domainServices] of Object.entries(this.hass.services)) {
       for (const service of Object.keys(domainServices)) {
         const serviceId = `${domain}.${service}`;
-        services.push({
-          value: serviceId,
-          label: serviceId,
-        });
+        services.push({ value: serviceId, label: serviceId });
       }
     }
-
     return services.sort((a, b) => a.label.localeCompare(b.label));
   }
 
@@ -65,25 +60,17 @@ export class MealPlanCardEditor extends LitElement {
                 multiple: true,
                 mode: 'dropdown',
                 options: [
-                  {
-                    value: OverviewField.SCHEDULES,
-                    label: localize('overview.schedules'),
-                  },
-                  {
-                    value: OverviewField.ACTIVE,
-                    label: localize('overview.active'),
-                  },
-                  {
-                    value: OverviewField.TODAY,
-                    label: localize('overview.today'),
-                  },
-                  {
-                    value: OverviewField.AVG_WEEK,
-                    label: localize('overview.avg_week'),
-                  },
+                  { value: OverviewField.SCHEDULES, label: localize('overview.schedules') },
+                  { value: OverviewField.ACTIVE, label: localize('overview.active') },
+                  { value: OverviewField.TODAY, label: localize('overview.today') },
+                  { value: OverviewField.AVG_WEEK, label: localize('overview.avg_week') },
                 ],
               },
             },
+          },
+          {
+            name: 'show_schedules',
+            selector: { boolean: {} },
           },
         ],
       },
@@ -139,6 +126,7 @@ export class MealPlanCardEditor extends LitElement {
         ],
       });
     }
+
     if (this._config.transport_type === TransportType.MQTT) {
       schema.push({
         type: 'grid',
@@ -159,6 +147,7 @@ export class MealPlanCardEditor extends LitElement {
         ],
       });
     }
+
     if (this._config.transport_type === TransportType.TUYA_SERVICE) {
       schema.push({
         type: 'grid',
@@ -166,9 +155,7 @@ export class MealPlanCardEditor extends LitElement {
           {
             name: 'device_id',
             required: true,
-            selector: {
-              device: {},
-            },
+            selector: { device: {} },
           },
           {
             name: 'read_action',
@@ -193,19 +180,16 @@ export class MealPlanCardEditor extends LitElement {
         ],
       });
     }
+
     return schema;
   }
-  /*
-   * Checks if all required fields in the current config are filled.
-   */
+
   private _allRequiredFieldsFilled(): boolean {
     if (!this._config) return false;
     const schema = this._computeSchema();
     return this._checkRequiredFields(schema);
   }
-  /**
-   *  Recursively checks required fields in the schema.
-   */
+
   private _checkRequiredFields(schema: Record<string, unknown>[]): boolean {
     for (const field of schema) {
       if (field.schema && Array.isArray(field.schema)) {
@@ -222,6 +206,7 @@ export class MealPlanCardEditor extends LitElement {
     }
     return true;
   }
+
   private _valueChanged(ev: CustomEvent) {
     this._config = ev.detail.value;
     if (this._allRequiredFieldsFilled()) {
@@ -237,7 +222,6 @@ export class MealPlanCardEditor extends LitElement {
 
   render() {
     const isValid = this._allRequiredFieldsFilled();
-
     return html`
       ${!isValid
         ? html`<ha-alert alert-type="warning">
@@ -277,12 +261,15 @@ export class MealPlanCardEditor extends LitElement {
         return localize('config.read_action_label');
       case 'device_id':
         return localize('config.device_id_label');
+      case 'show_schedules':
+        return localize('config.show_schedules_label');
       case 'incomplete_configuration':
         return localize('config.incomplete_configuration');
       default:
         return undefined;
     }
   };
+
   private computeHelper = (schema: { name: string }) => {
     switch (schema.name) {
       case 'sensor':
@@ -297,6 +284,8 @@ export class MealPlanCardEditor extends LitElement {
         return localize('config.overview_fields_helper');
       case 'transport_type':
         return localize('config.transport_helper');
+      case 'show_schedules':
+        return localize('config.show_schedules_helper');
       default:
         return undefined;
     }

--- a/src/config-form.ts
+++ b/src/config-form.ts
@@ -60,10 +60,22 @@ export class MealPlanCardEditor extends LitElement {
                 multiple: true,
                 mode: 'dropdown',
                 options: [
-                  { value: OverviewField.SCHEDULES, label: localize('overview.schedules') },
-                  { value: OverviewField.ACTIVE, label: localize('overview.active') },
-                  { value: OverviewField.TODAY, label: localize('overview.today') },
-                  { value: OverviewField.AVG_WEEK, label: localize('overview.avg_week') },
+                  {
+                    value: OverviewField.SCHEDULES,
+                    label: localize('overview.schedules'),
+                  },
+                  {
+                    value: OverviewField.ACTIVE,
+                    label: localize('overview.active'),
+                  },
+                  {
+                    value: OverviewField.TODAY,
+                    label: localize('overview.today'),
+                  },
+                  {
+                    value: OverviewField.AVG_WEEK,
+                    label: localize('overview.avg_week'),
+                  },
                 ],
               },
             },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -69,7 +69,9 @@
     "write_action_label": "Write Action",
     "dp_code_label": "Data Point Code",
     "device_id_label": "Device ID",
-    "incomplete_configuration": "Incomplete Configuration"
+    "incomplete_configuration": "Incomplete Configuration",
+    "show_schedules_label": "Show schedules",
+    "show_schedules_helper": "Show the feeding schedule directly on the card without opening the manage dialog"
   },
   "overview": {
     "schedules": "Schedules",

--- a/src/locales/localize.ts
+++ b/src/locales/localize.ts
@@ -3,9 +3,10 @@ import sv from './sv.json';
 import ru from './ru.json';
 import es from './es.json';
 import cs from './cs.json';
+import nl from './nl.json';
 
 type Translation = Record<string, unknown>;
-const translations = { en, sv, ru, es, cs } satisfies Record<
+const translations = { en, sv, ru, es, cs, nl } satisfies Record<
   string,
   Translation
 >;

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -1,0 +1,82 @@
+{
+    "common": {
+        "back": "Terug",
+        "cancel": "Annuleren",
+        "save": "Opslaan",
+        "delete": "Verwijderen",
+        "close": "Sluiten",
+        "portion": "Portie",
+        "time": "Tijd",
+        "days": "Dagen",
+        "enabled": "Ingeschakeld",
+        "disabled": "Uitgeschakeld",
+        "every_day": "Elke dag",
+        "no_days": "Geen dagen",
+        "add_meal": "Maaltijd toevoegen"
+    },
+    "days": {
+        "short": {
+            "monday": "M",
+            "tuesday": "D",
+            "wednesday": "W",
+            "thursday": "D",
+            "friday": "V",
+            "saturday": "Z",
+            "sunday": "Z"
+        },
+        "full": {
+            "monday": "Maandag",
+            "tuesday": "Dinsdag",
+            "wednesday": "Woensdag",
+            "thursday": "Donderdag",
+            "friday": "Vrijdag",
+            "saturday": "Zaterdag",
+            "sunday": "Zondag"
+        }
+    },
+    "main": {
+        "manage_schedules": "Beheren",
+        "configuration_required": "Configuratie vereist",
+        "configuration_instructions": "Configureer een sensor en fabrikant in de kaartinstellingen."
+    },
+    "schedule_view": {
+        "manage_schedules": "Beheren",
+        "edit_feeding_time": "Voertijd bewerken",
+        "no_meals_scheduled": "Geen maaltijden gepland",
+        "click_add_meal_to_get_started": "Klik op 'Maaltijd toevoegen' om het eerste voerschema aan te maken",
+        "sensor_unavailable": "Entiteit niet beschikbaar",
+        "sensor_unavailable_message": "De geselecteerde sensor is niet beschikbaar. Je kunt geen wijzigingen opslaan totdat het apparaat bereikbaar is."
+    },
+    "meal_card": {
+        "edit_meal": "Maaltijd bewerken",
+        "confirm_delete": "Weet je zeker dat je deze maaltijd wilt verwijderen?"
+    },
+    "config": {
+        "portion_label": "Portiegrootte",
+        "portion_helper": "Gram per portie",
+        "sensor_label": "Maaltijdplan sensor",
+        "sensor_helper": "Selecteer de sensor of tekst-entiteit met de maaltijdplandata",
+        "manufacturer_label": "Voederprofiel",
+        "manufacturer_helper": "Selecteer de fabrikant en het model van de voerautomaat",
+        "title_label": "Titel",
+        "overview_fields_label": "Overzichtschips",
+        "overview_fields_helper": "Selecteer welke chips in de overzichtrij worden getoond",
+        "helper_label": "Hulpentiteit (optioneel)",
+        "helper_helper": "Deze input_text dient als reserveopslag voor je voerschema. Als de sensor niet beschikbaar is, herstelt de kaart het schema vanuit deze helper.",
+        "transport_label": "Transporttype",
+        "transport_helper": "Hoe data te schrijven: Sensor (via set_value service) of MQTT (publiceer naar zigbee2mqtt topic)",
+        "read_action_label": "Leesactie",
+        "write_action_label": "Schrijfactie",
+        "dp_code_label": "Datapuntcode",
+        "device_id_label": "Apparaat-ID",
+        "incomplete_configuration": "Onvolledige configuratie",
+        "show_schedules_label": "Toon schema",
+        "show_schedules_helper": "Toon het voerschema direct op de kaart zonder het beheerdialoogvenster te openen"
+    },
+    "overview": {
+        "schedules": "Schema's",
+        "active": "Actief",
+        "today": "Vandaag",
+        "avg_week": "Gem/Week"
+    }
+}

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -1,82 +1,82 @@
 {
-    "common": {
-        "back": "Terug",
-        "cancel": "Annuleren",
-        "save": "Opslaan",
-        "delete": "Verwijderen",
-        "close": "Sluiten",
-        "portion": "Portie",
-        "time": "Tijd",
-        "days": "Dagen",
-        "enabled": "Ingeschakeld",
-        "disabled": "Uitgeschakeld",
-        "every_day": "Elke dag",
-        "no_days": "Geen dagen",
-        "add_meal": "Maaltijd toevoegen"
+  "common": {
+    "back": "Terug",
+    "cancel": "Annuleren",
+    "save": "Opslaan",
+    "delete": "Verwijderen",
+    "close": "Sluiten",
+    "portion": "Portie",
+    "time": "Tijd",
+    "days": "Dagen",
+    "enabled": "Ingeschakeld",
+    "disabled": "Uitgeschakeld",
+    "every_day": "Elke dag",
+    "no_days": "Geen dagen",
+    "add_meal": "Maaltijd toevoegen"
+  },
+  "days": {
+    "short": {
+      "monday": "M",
+      "tuesday": "D",
+      "wednesday": "W",
+      "thursday": "D",
+      "friday": "V",
+      "saturday": "Z",
+      "sunday": "Z"
     },
-    "days": {
-        "short": {
-            "monday": "M",
-            "tuesday": "D",
-            "wednesday": "W",
-            "thursday": "D",
-            "friday": "V",
-            "saturday": "Z",
-            "sunday": "Z"
-        },
-        "full": {
-            "monday": "Maandag",
-            "tuesday": "Dinsdag",
-            "wednesday": "Woensdag",
-            "thursday": "Donderdag",
-            "friday": "Vrijdag",
-            "saturday": "Zaterdag",
-            "sunday": "Zondag"
-        }
-    },
-    "main": {
-        "manage_schedules": "Beheren",
-        "configuration_required": "Configuratie vereist",
-        "configuration_instructions": "Configureer een sensor en fabrikant in de kaartinstellingen."
-    },
-    "schedule_view": {
-        "manage_schedules": "Beheren",
-        "edit_feeding_time": "Voertijd bewerken",
-        "no_meals_scheduled": "Geen maaltijden gepland",
-        "click_add_meal_to_get_started": "Klik op 'Maaltijd toevoegen' om het eerste voerschema aan te maken",
-        "sensor_unavailable": "Entiteit niet beschikbaar",
-        "sensor_unavailable_message": "De geselecteerde sensor is niet beschikbaar. Je kunt geen wijzigingen opslaan totdat het apparaat bereikbaar is."
-    },
-    "meal_card": {
-        "edit_meal": "Maaltijd bewerken",
-        "confirm_delete": "Weet je zeker dat je deze maaltijd wilt verwijderen?"
-    },
-    "config": {
-        "portion_label": "Portiegrootte",
-        "portion_helper": "Gram per portie",
-        "sensor_label": "Maaltijdplan sensor",
-        "sensor_helper": "Selecteer de sensor of tekst-entiteit met de maaltijdplandata",
-        "manufacturer_label": "Voederprofiel",
-        "manufacturer_helper": "Selecteer de fabrikant en het model van de voerautomaat",
-        "title_label": "Titel",
-        "overview_fields_label": "Overzichtschips",
-        "overview_fields_helper": "Selecteer welke chips in de overzichtrij worden getoond",
-        "helper_label": "Hulpentiteit (optioneel)",
-        "helper_helper": "Deze input_text dient als reserveopslag voor je voerschema. Als de sensor niet beschikbaar is, herstelt de kaart het schema vanuit deze helper.",
-        "transport_label": "Transporttype",
-        "transport_helper": "Hoe data te schrijven: Sensor (via set_value service) of MQTT (publiceer naar zigbee2mqtt topic)",
-        "read_action_label": "Leesactie",
-        "write_action_label": "Schrijfactie",
-        "dp_code_label": "Datapuntcode",
-        "device_id_label": "Apparaat-ID",
-        "incomplete_configuration": "Onvolledige configuratie",
-        "show_schedules_label": "Toon schema",
-        "show_schedules_helper": "Toon het voerschema direct op de kaart zonder het beheerdialoogvenster te openen"
-    },
-    "overview": {
-        "schedules": "Schema's",
-        "active": "Actief",
-        "today": "Vandaag",
-        "avg_week": "Gem/Week"
+    "full": {
+      "monday": "Maandag",
+      "tuesday": "Dinsdag",
+      "wednesday": "Woensdag",
+      "thursday": "Donderdag",
+      "friday": "Vrijdag",
+      "saturday": "Zaterdag",
+      "sunday": "Zondag"
     }
+  },
+  "main": {
+    "manage_schedules": "Beheren",
+    "configuration_required": "Configuratie vereist",
+    "configuration_instructions": "Configureer een sensor en fabrikant in de kaartinstellingen."
+  },
+  "schedule_view": {
+    "manage_schedules": "Beheren",
+    "edit_feeding_time": "Voertijd bewerken",
+    "no_meals_scheduled": "Geen maaltijden gepland",
+    "click_add_meal_to_get_started": "Klik op 'Maaltijd toevoegen' om het eerste voerschema aan te maken",
+    "sensor_unavailable": "Entiteit niet beschikbaar",
+    "sensor_unavailable_message": "De geselecteerde sensor is niet beschikbaar. Je kunt geen wijzigingen opslaan totdat het apparaat bereikbaar is."
+  },
+  "meal_card": {
+    "edit_meal": "Maaltijd bewerken",
+    "confirm_delete": "Weet je zeker dat je deze maaltijd wilt verwijderen?"
+  },
+  "config": {
+    "portion_label": "Portiegrootte",
+    "portion_helper": "Gram per portie",
+    "sensor_label": "Maaltijdplan sensor",
+    "sensor_helper": "Selecteer de sensor of tekst-entiteit met de maaltijdplandata",
+    "manufacturer_label": "Voederprofiel",
+    "manufacturer_helper": "Selecteer de fabrikant en het model van de voerautomaat",
+    "title_label": "Titel",
+    "overview_fields_label": "Overzichtschips",
+    "overview_fields_helper": "Selecteer welke chips in de overzichtrij worden getoond",
+    "helper_label": "Hulpentiteit (optioneel)",
+    "helper_helper": "Deze input_text dient als reserveopslag voor je voerschema. Als de sensor niet beschikbaar is, herstelt de kaart het schema vanuit deze helper.",
+    "transport_label": "Transporttype",
+    "transport_helper": "Hoe data te schrijven: Sensor (via set_value service) of MQTT (publiceer naar zigbee2mqtt topic)",
+    "read_action_label": "Leesactie",
+    "write_action_label": "Schrijfactie",
+    "dp_code_label": "Datapuntcode",
+    "device_id_label": "Apparaat-ID",
+    "incomplete_configuration": "Onvolledige configuratie",
+    "show_schedules_label": "Toon schema",
+    "show_schedules_helper": "Toon het voerschema direct op de kaart zonder het beheerdialoogvenster te openen"
+  },
+  "overview": {
+    "schedules": "Schema's",
+    "active": "Actief",
+    "today": "Vandaag",
+    "avg_week": "Gem/Week"
+  }
 }

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -69,7 +69,9 @@
     "write_action_label": "Skriva åtgärd",
     "dp_code_label": "Datapunktkod",
     "device_id_label": "Enhets-ID",
-    "incomplete_configuration": "Ofullständig konfiguration"
+    "incomplete_configuration": "Ofullständig konfiguration",
+    "show_schedules_label": "Visa schema",
+    "show_schedules_helper": "Visa matningsschemat direkt på kortet utan att öppna hanteringsdialogen"
   },
   "overview": {
     "schedules": "Scheman",

--- a/src/main.ts
+++ b/src/main.ts
@@ -124,9 +124,9 @@ export class MealPlanCard extends LitElement {
         ></meal-overview>
         <div class="inline-schedules">
           ${this.mealState.meals.length === 0
-          ? html`<p>${localize('schedule_view.no_meals_scheduled')}</p>`
-          : this.mealState.meals.map(
-            (meal, index) => html`
+            ? html`<p>${localize('schedule_view.no_meals_scheduled')}</p>`
+            : this.mealState.meals.map(
+                (meal, index) => html`
                   <meal-card
                     .meal=${meal}
                     .index=${index}
@@ -134,17 +134,17 @@ export class MealPlanCard extends LitElement {
                     .onMealAction=${this._handleMealAction.bind(this)}
                   ></meal-card>
                 `,
-          )}
+              )}
         </div>
         <div class="card-actions">
           <ha-button
             appearance="plain"
             variant="brand"
             @click=${() => {
-          this._openAddOnLoad = true;
-          this._editMealIndex = undefined;
-          this._dialogOpen = true;
-        }}
+              this._openAddOnLoad = true;
+              this._editMealIndex = undefined;
+              this._dialogOpen = true;
+            }}
           >
             ${localize('common.add_meal')}
           </ha-button>
@@ -189,10 +189,10 @@ export class MealPlanCard extends LitElement {
         .openAddOnLoad=${this._openAddOnLoad}
         .editMealIndex=${this._editMealIndex}
         @schedule-closed=${() => {
-        this._dialogOpen = false;
-        this._openAddOnLoad = false;
-        this._editMealIndex = undefined;
-      }}
+          this._dialogOpen = false;
+          this._openAddOnLoad = false;
+          this._editMealIndex = undefined;
+        }}
       ></schedule-view>
     `;
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,8 +5,9 @@ import { MealStateController } from './mealStateController';
 import type { HomeAssistant, MealPlanCardConfig } from './types';
 import { OverviewField, TransportType } from './types';
 import { getProfileWithTransformer } from './profiles/profiles';
-import './components/overview';
-import './components/schedule-view';
+import './components/overview.js';
+import './components/schedule-view.js';
+import './components/meal-card.js';
 import { log } from './logger';
 import { getVersionString } from './version';
 import './config-form.js';
@@ -17,22 +18,24 @@ export class MealPlanCard extends LitElement {
   @property({ type: Object }) config!: MealPlanCardConfig;
   @state() public mealState?: MealStateController;
   @state() private _dialogOpen = false;
+  @state() private _openAddOnLoad = false;
 
   static get styles() {
     return css`
-      :host,
-      ha-card {
-        display: block;
-        height: 100%;
-        overflow: hidden;
-      }
+    :host,
+    ha-card {
+      display: block;
+      height: 100%;
+      overflow: hidden;
+    }
+    .inline-schedules {
+      padding: 0 16px 8px 16px;
+    }
     `;
   }
-
   setConfig(config: MealPlanCardConfig) {
     this.config = config;
 
-    // Initialize controller if we have all prerequisites
     if (this.hass && this.config.manufacturer) {
       const profile = getProfileWithTransformer(this.config.manufacturer);
 
@@ -52,7 +55,6 @@ export class MealPlanCard extends LitElement {
 
     await setLanguage(this.hass?.language);
 
-    // Initialize meal state controller (hass is now available)
     if (this.config.manufacturer) {
       const profile = getProfileWithTransformer(this.config.manufacturer);
 
@@ -91,6 +93,40 @@ export class MealPlanCard extends LitElement {
       return this.renderConfigurationRequired();
     }
 
+    if (this.config.show_schedules) {
+      return html`
+        <meal-overview
+          .meals=${this.mealState.meals}
+          .portions=${this.config?.portions}
+          .overviewFields=${this.config.overview_fields}
+        ></meal-overview>
+        <div class="inline-schedules">
+          ${this.mealState.meals.length === 0
+          ? html`<p>${localize('schedule_view.no_meals_scheduled')}</p>`
+          : this.mealState.meals.map(
+            (meal, index) => html`
+                  <meal-card
+                    .meal=${meal}
+                    .index=${index}
+                    .profile=${this.mealState!.profile}
+                  ></meal-card>
+                `,
+          )}
+        <div class="card-actions">
+          <ha-button
+            appearance="plain"
+            variant="brand"
+            @click=${() => {
+                  this._openAddOnLoad = true;
+                  this._dialogOpen = true;
+                }}
+          >
+            ${localize('common.add_meal')}
+          </ha-button>
+        </div>
+      `;
+    }
+
     return html`
       <meal-overview
         .meals=${this.mealState.meals}
@@ -125,16 +161,15 @@ export class MealPlanCard extends LitElement {
       <schedule-view
         .mealState=${this.mealState}
         .hass=${this.hass}
+        .openAddOnLoad=${this._openAddOnLoad}
         @schedule-closed=${() => {
-          this._dialogOpen = false;
-        }}
+        this._dialogOpen = false;
+        this._openAddOnLoad = false;
+      }}
       ></schedule-view>
     `;
   }
 
-  //static getConfigForm(): ReturnType<typeof generateConfigFormSchema> {
-  //  return generateConfigFormSchema();
-  ///}
   static getConfigElement() {
     return document.createElement('mealplan-card-editor');
   }
@@ -150,6 +185,7 @@ export class MealPlanCard extends LitElement {
         OverviewField.AVG_WEEK,
       ],
       transport_type: TransportType.SENSOR,
+      show_schedules: false,
     } as MealPlanCardConfig;
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@
 import { customElement, property, state } from 'lit/decorators.js';
 import { localize, setLanguage } from './locales/localize';
 import { MealStateController } from './mealStateController';
-import type { HomeAssistant, MealPlanCardConfig } from './types';
+import type { HomeAssistant, MealPlanCardConfig, FeedingTime } from './types';
 import { OverviewField, TransportType } from './types';
 import { getProfileWithTransformer } from './profiles/profiles';
 import './components/overview.js';
@@ -19,20 +19,22 @@ export class MealPlanCard extends LitElement {
   @state() public mealState?: MealStateController;
   @state() private _dialogOpen = false;
   @state() private _openAddOnLoad = false;
+  @state() private _editMealIndex: number | undefined = undefined;
 
   static get styles() {
     return css`
-    :host,
-    ha-card {
-      display: block;
-      height: 100%;
-      overflow: hidden;
-    }
-    .inline-schedules {
-      padding: 0 16px 8px 16px;
-    }
+      :host,
+      ha-card {
+        display: block;
+        height: 100%;
+        overflow: hidden;
+      }
+      .inline-schedules {
+        padding: 0 16px 8px 16px;
+      }
     `;
   }
+
   setConfig(config: MealPlanCardConfig) {
     this.config = config;
 
@@ -88,6 +90,26 @@ export class MealPlanCard extends LitElement {
     `;
   }
 
+  private _handleMealAction(
+    action: string,
+    index: number,
+    meal: FeedingTime,
+  ): void {
+    if (action === 'edit') {
+      this._editMealIndex = index;
+      this._openAddOnLoad = false;
+      this._dialogOpen = true;
+    } else if (action === 'delete') {
+      const updated = this.mealState!.meals.filter((_, i) => i !== index);
+      this.mealState!.saveMeals(updated);
+    } else if (action === 'update') {
+      const updated = this.mealState!.meals.map((m, i) =>
+        i === index ? meal : m,
+      );
+      this.mealState!.saveMeals(updated);
+    }
+  }
+
   private renderContent() {
     if (!this.mealState) {
       return this.renderConfigurationRequired();
@@ -109,17 +131,20 @@ export class MealPlanCard extends LitElement {
                     .meal=${meal}
                     .index=${index}
                     .profile=${this.mealState!.profile}
+                    .onMealAction=${this._handleMealAction.bind(this)}
                   ></meal-card>
                 `,
           )}
+        </div>
         <div class="card-actions">
           <ha-button
             appearance="plain"
             variant="brand"
             @click=${() => {
-                  this._openAddOnLoad = true;
-                  this._dialogOpen = true;
-                }}
+          this._openAddOnLoad = true;
+          this._editMealIndex = undefined;
+          this._dialogOpen = true;
+        }}
           >
             ${localize('common.add_meal')}
           </ha-button>
@@ -162,9 +187,11 @@ export class MealPlanCard extends LitElement {
         .mealState=${this.mealState}
         .hass=${this.hass}
         .openAddOnLoad=${this._openAddOnLoad}
+        .editMealIndex=${this._editMealIndex}
         @schedule-closed=${() => {
         this._dialogOpen = false;
         this._openAddOnLoad = false;
+        this._editMealIndex = undefined;
       }}
       ></schedule-view>
     `;

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,9 @@ export class MealPlanCard extends LitElement {
       .inline-schedules {
         padding: 0 16px 8px 16px;
       }
+      .inline-schedules.no-overview {
+        padding-top: 8px;
+      }
     `;
   }
 
@@ -116,13 +119,16 @@ export class MealPlanCard extends LitElement {
     }
 
     if (this.config.show_schedules) {
+      const hasOverview =
+        this.config.overview_fields && this.config.overview_fields.length > 0;
+
       return html`
         <meal-overview
           .meals=${this.mealState.meals}
           .portions=${this.config?.portions}
           .overviewFields=${this.config.overview_fields}
         ></meal-overview>
-        <div class="inline-schedules">
+        <div class="inline-schedules ${!hasOverview ? 'no-overview' : ''}">
           ${this.mealState.meals.length === 0
             ? html`<p>${localize('schedule_view.no_meals_scheduled')}</p>`
             : this.mealState.meals.map(

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,6 +71,7 @@ export interface CardConfig {
   manufacturer?: string;
   model?: string;
   transport_type: TransportType;
+  show_schedules?: boolean;
 }
 
 /**


### PR DESCRIPTION
- Add show_schedules config option to display schedules inline on card
- When show_schedules is true, show schedules directly without Manage dialog
- Add + button to open add meal dialog directly when show_schedules is true
- Add Dutch (nl) translation
- Add show_schedules toggle to config editor UI
- Backwards compatible: show_schedules defaults to false

added config option: show_schedules: true  (enables this feature)