### PR TITLE
Feature: click to edit directly, delete button in edit dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ Thumbs.db
 .github/instructions/*
 target
 .npmrc
+
+deploy.sh

--- a/src/components/edit-dialog.ts
+++ b/src/components/edit-dialog.ts
@@ -87,6 +87,7 @@ export class MealEditDialog extends LitElement {
     label {
       font-weight: 500;
       font-size: 0.95em;
+      color: var(--primary-text-color);
     }
     input[type='time'],
     input[type='number'] {
@@ -96,6 +97,13 @@ export class MealEditDialog extends LitElement {
       font-size: 1em;
       width: 100%;
       box-sizing: border-box;
+      background-color: var(--card-background-color);
+      color: var(--primary-text-color);
+      outline: none;
+    }
+    input[type='time']:focus,
+    input[type='number']:focus {
+      border-color: var(--primary-color);
     }
     .edit-mode .days-row {
       justify-content: center;

--- a/src/components/meal-card.ts
+++ b/src/components/meal-card.ts
@@ -11,7 +11,6 @@ export class MealCard extends LitElement {
   @property({ type: Object }) meal!: FeedingTime;
   @property({ type: Number }) index: number = 0;
   @property({ type: Object }) profile!: DeviceProfile;
-  @property({ type: Boolean }) expanded = false;
   @property({ attribute: false }) onMealAction?: MealActionHandler;
 
   static styles = css`
@@ -34,6 +33,7 @@ export class MealCard extends LitElement {
     }
     .meal-card-header:hover {
       background: var(--secondary-background-color, #f5f5f5);
+      border-radius: var(--meal-card-border-radius, 6px);
     }
     .meal-card-header ha-switch,
     .meal-card-header ha-icon {
@@ -88,9 +88,6 @@ export class MealCard extends LitElement {
       ha-switch {
         order: 2;
       }
-      .meal-card-expand-icon {
-        order: 3;
-      }
       .meal-card-days {
         order: 10;
         width: 100%;
@@ -101,75 +98,11 @@ export class MealCard extends LitElement {
         row-gap: 2px;
       }
     }
-    .meal-card-expand-icon {
-      transition: transform 0.2s;
-      margin-left: 4px;
-      --mdc-icon-size: 24px;
-      color: var(--primary-color);
-      cursor: pointer;
-    }
-    .meal-card-expand-icon:hover {
-      color: var(--primary-color-dark, var(--primary-color));
-    }
-    .meal-card-expand-icon.expanded {
-      transform: rotate(180deg);
-    }
-    .meal-card-details {
-      padding: 0 10px 8px 10px;
-      border-top: 1px solid
-        var(--meal-card-border-color, var(--divider-color, #e0e0e0));
-      background: var(
-        --meal-card-details-background,
-        var(--secondary-background-color, #f5f5f5)
-      );
-    }
-    .meal-card-row {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      padding: 4px 0;
-    }
-    .meal-card-label {
-      font-weight: 500;
-      color: var(--secondary-text-color);
-      font-size: 0.85em;
-    }
-    .meal-card-value {
-      font-size: 0.9em;
-    }
-    .meal-card-actions-section {
-      margin-top: 8px;
-      padding-top: 8px;
-      display: flex;
-      gap: 8px;
-    }
-    .meal-card-actions-section ha-button {
-      flex: 1;
-      --ha-button-height: 32px;
-    }
-    .meal-card-actions-section .delete-button {
-      --mdc-theme-primary: var(--error-color, #db4437);
-    }
   `;
-  private toggleExpand() {
-    const wasExpanded = this.expanded;
-    this.expanded = !this.expanded;
 
-    if (this.expanded && !wasExpanded) {
-      // Collapse all sibling cards
-      const parent = this.parentElement;
-      if (parent) {
-        parent.querySelectorAll<MealCard>('meal-card').forEach((card) => {
-          if (card !== this && card.expanded) {
-            card.expanded = false;
-          }
-        });
-      }
-
-      // Scroll card into view after expanding
-      this.updateComplete.then(() => {
-        this.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-      });
+  private handleClick() {
+    if (this.onMealAction && hasProfileField(this.profile, ProfileField.EDIT)) {
+      this.onMealAction('edit', this.index, this.meal);
     }
   }
 
@@ -196,7 +129,7 @@ export class MealCard extends LitElement {
 
     return html`
       <div class="meal-card">
-        <div class="meal-card-header" @click=${this.toggleExpand}>
+        <div class="meal-card-header" @click=${this.handleClick}>
           <div class="meal-card-number">${this.index + 1}</div>
           <div class="meal-card-summary">
             <div class="meal-card-time">${time}</div>
@@ -204,21 +137,6 @@ export class MealCard extends LitElement {
           </div>
           <div class="meal-card-days">${this.renderDaysInline()}</div>
           ${this.renderEnabledToggle()}
-          <ha-icon
-            class="meal-card-expand-icon ${this.expanded ? 'expanded' : ''}"
-            icon="mdi:chevron-down"
-          ></ha-icon>
-        </div>
-        ${this.expanded ? this.renderDetails() : ''}
-      </div>
-    `;
-  }
-
-  private renderDetails() {
-    return html`
-      <div class="meal-card-details">
-        <div class="meal-card-actions-section">
-          ${this.renderEditButton()} ${this.renderDeleteButton()}
         </div>
       </div>
     `;
@@ -253,43 +171,6 @@ export class MealCard extends LitElement {
           ? localize('common.enabled')
           : localize('common.disabled')}"
       ></ha-switch>
-    `;
-  }
-
-  private renderEditButton() {
-    if (!hasProfileField(this.profile, ProfileField.EDIT)) return '';
-
-    return html`
-      <ha-button
-        @click=${() => {
-          if (this.onMealAction) {
-            this.onMealAction('edit', this.index, this.meal);
-          }
-        }}
-      >
-        <ha-icon icon="mdi:pencil" slot="icon"></ha-icon>
-        ${localize('meal_card.edit_meal')}
-      </ha-button>
-    `;
-  }
-
-  private renderDeleteButton() {
-    if (!hasProfileField(this.profile, ProfileField.DELETE)) return '';
-
-    return html`
-      <ha-button
-        class="delete-button"
-        @click=${() => {
-          if (confirm(localize('meal_card.confirm_delete'))) {
-            if (this.onMealAction) {
-              this.onMealAction('delete', this.index, this.meal);
-            }
-          }
-        }}
-      >
-        <ha-icon icon="mdi:delete" slot="icon"></ha-icon>
-        ${localize('common.delete')}
-      </ha-button>
     `;
   }
 }

--- a/src/components/meal-card.ts
+++ b/src/components/meal-card.ts
@@ -16,11 +16,15 @@ export class MealCard extends LitElement {
 
   static styles = css`
     .meal-card {
-      background: var(--card-background-color, #fff);
-      border-radius: 6px;
+      background: var(
+        --meal-card-background,
+        var(--card-background-color, #fff)
+      );
+      border-radius: var(--meal-card-border-radius, 6px);
       margin-bottom: 6px;
-      border: 1px solid var(--divider-color, rgba(0, 0, 0, 0.12));
-      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+      border: 1px solid
+        var(--meal-card-border-color, var(--divider-color, rgba(0, 0, 0, 0.12)));
+      box-shadow: var(--meal-card-box-shadow, 0 1px 3px rgba(0, 0, 0, 0.08));
     }
     .meal-card-header {
       display: flex;
@@ -112,8 +116,12 @@ export class MealCard extends LitElement {
     }
     .meal-card-details {
       padding: 0 10px 8px 10px;
-      border-top: 1px solid var(--divider-color, #e0e0e0);
-      background: var(--secondary-background-color, #f5f5f5);
+      border-top: 1px solid
+        var(--meal-card-border-color, var(--divider-color, #e0e0e0));
+      background: var(
+        --meal-card-details-background,
+        var(--secondary-background-color, #f5f5f5)
+      );
     }
     .meal-card-row {
       display: flex;
@@ -143,7 +151,6 @@ export class MealCard extends LitElement {
       --mdc-theme-primary: var(--error-color, #db4437);
     }
   `;
-
   private toggleExpand() {
     const wasExpanded = this.expanded;
     this.expanded = !this.expanded;

--- a/src/components/schedule-view.ts
+++ b/src/components/schedule-view.ts
@@ -1,8 +1,3 @@
-/**
- * ScheduleView component for managing meal schedules
- * Self-contained LitElement component with internal state
- */
-
 import { LitElement, html, css } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { localize } from '../locales/localize';
@@ -16,14 +11,11 @@ import type { MealEditDialog } from './edit-dialog';
 import './meal-card';
 import './message-banner';
 
-/**
- * Schedule view component
- * Emits: 'schedule-closed' when dialog closes
- */
 @customElement('schedule-view')
 export class ScheduleView extends LitElement {
   @property({ type: Object }) mealState!: MealStateController;
   @property({ type: Object }) hass!: HomeAssistant;
+  @property({ type: Boolean }) openAddOnLoad = false;
 
   @state() private draftMeals: FeedingTime[] = [];
   @state() private editMeal: EditMealState | null = null;
@@ -34,22 +26,21 @@ export class ScheduleView extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
-    // Initialize draft from current meals (sorted by time)
     this.draftMeals = this.sortMealsByTime([...this.mealState.meals]);
 
     this.mealState.isDataAvailable().then((available) => {
       this.dataAvailable = available;
     });
 
-    // Subscribe to meals changes from MealStateController
     this.unsubscribe = this.mealState.subscribe(() => {
       this.syncMealsWithController();
     });
+
+    if (this.openAddOnLoad) {
+      this.handleOpenAdd();
+    }
   }
 
-  /**
-   * Sort meals by time (hour, then minute)
-   */
   private sortMealsByTime(meals: FeedingTime[]): FeedingTime[] {
     return [...meals].sort(
       (a, b) =>
@@ -88,9 +79,6 @@ export class ScheduleView extends LitElement {
     }
   `;
 
-  /**
-   * Reset draft to match controller's saved meals
-   */
   private syncMealsWithController(): void {
     this.draftMeals = this.sortMealsByTime([...this.mealState.meals]);
   }
@@ -100,15 +88,15 @@ export class ScheduleView extends LitElement {
       this.draftMeals.map((m, i) => (i === index ? meal : m)),
     );
   }
+
   public getMeals(): FeedingTime[] {
     return this.draftMeals;
   }
+
   public getEditMeals(): EditMealState | null {
     return this.editMeal;
   }
-  /**
-   * Unified handler for meal actions from meal-card
-   */
+
   public handleMealAction(
     action: 'update' | 'delete' | 'edit',
     index: number,
@@ -124,9 +112,6 @@ export class ScheduleView extends LitElement {
     }
   }
 
-  /**
-   * Add new meal to draft
-   */
   public addMeal(meal: FeedingTime): void {
     this.draftMeals = this.sortMealsByTime([...this.draftMeals, meal]);
   }
@@ -156,10 +141,8 @@ export class ScheduleView extends LitElement {
     const { meal, index } = e.detail;
 
     if (index !== undefined && index >= 0) {
-      // Update existing meal
       this.updateMeal(index, meal);
     } else {
-      // Add new meal
       this.addMeal(meal);
     }
 
@@ -175,9 +158,6 @@ export class ScheduleView extends LitElement {
     return !areMealsEqual(this.draftMeals, this.mealState.meals);
   }
 
-  /**
-   * Render meal form (for adding or editing)
-   */
   private renderMealForm() {
     if (this.editMeal === null) return '';
 
@@ -203,12 +183,12 @@ export class ScheduleView extends LitElement {
         <ha-button
           slot="primaryAction"
           @click=${() => {
-            const dialog =
-              this.shadowRoot?.querySelector<MealEditDialog>(
-                'meal-edit-dialog',
-              );
-            dialog?.handleSave();
-          }}
+        const dialog =
+          this.shadowRoot?.querySelector<MealEditDialog>(
+            'meal-edit-dialog',
+          );
+        dialog?.handleSave();
+      }}
         >
           ${localize('common.save')}
         </ha-button>
@@ -216,9 +196,6 @@ export class ScheduleView extends LitElement {
     `;
   }
 
-  /**
-   * Render empty state when no meals exist
-   */
   private renderEmptyState() {
     return html`
       <div class="empty-state">
@@ -233,9 +210,6 @@ export class ScheduleView extends LitElement {
     `;
   }
 
-  /**
-   * Render Add Meal button if profile allows it
-   */
   private renderAddButton() {
     if (!hasProfileField(this.mealState.profile, ProfileField.ADD)) return '';
 
@@ -250,9 +224,6 @@ export class ScheduleView extends LitElement {
     `;
   }
 
-  /**
-   * Render card-based view
-   */
   private renderCardView() {
     if (this.editMeal !== null) return '';
     if (!this.mealState.profile) return '';
@@ -266,9 +237,9 @@ export class ScheduleView extends LitElement {
       ></message-banner>
       <div class="schedule-cards">
         ${this.draftMeals.length === 0
-          ? this.renderEmptyState()
-          : this.draftMeals.map(
-              (meal, index) => html`
+        ? this.renderEmptyState()
+        : this.draftMeals.map(
+          (meal, index) => html`
                 <meal-card
                   .meal=${meal}
                   .index=${index}
@@ -277,7 +248,7 @@ export class ScheduleView extends LitElement {
                 >
                 </meal-card>
               `,
-            )}
+        )}
       </div>
       <ha-dialog-footer slot="footer">
         ${this.renderAddButton()}

--- a/src/components/schedule-view.ts
+++ b/src/components/schedule-view.ts
@@ -16,6 +16,7 @@ export class ScheduleView extends LitElement {
   @property({ type: Object }) mealState!: MealStateController;
   @property({ type: Object }) hass!: HomeAssistant;
   @property({ type: Boolean }) openAddOnLoad = false;
+  @property({ type: Number }) editMealIndex?: number;
 
   @state() private draftMeals: FeedingTime[] = [];
   @state() private editMeal: EditMealState | null = null;
@@ -36,7 +37,6 @@ export class ScheduleView extends LitElement {
       this.syncMealsWithController();
     });
 
-    // Use setTimeout to ensure properties are set before checking
     setTimeout(() => {
       if (this.openAddOnLoad) {
         this.handleOpenAdd();
@@ -85,6 +85,32 @@ export class ScheduleView extends LitElement {
     }
     .empty-state-subtitle {
       font-size: 0.9em;
+    }
+    .edit-footer {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 32px 0px 0px 0px;
+      width: 100%;
+      box-sizing: border-box;
+      border-top: 1px solid var(--divider-color, rgba(0, 0, 0, 0.12));
+      margin-top: 8px;
+    }
+    .delete-link {
+      background: none;
+      border: none;
+      cursor: pointer;
+      color: var(--error-color, #b00020);
+      font-size: 0.875rem;
+      font-weight: 500;
+      padding: 8px 16px;
+      border-radius: 18px;
+      font-family: inherit;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+    .delete-link:hover {
+      background-color: rgba(var(--rgb-error-color, 176, 0, 32), 0.1);
     }
   `;
 
@@ -146,16 +172,32 @@ export class ScheduleView extends LitElement {
     this.dispatchEvent(new ScheduleClosedEvent());
   }
 
-  public handleEditSave(e: CustomEvent<EditMealState>) {
+  public async handleEditSave(e: CustomEvent<EditMealState>) {
     const { meal, index } = e.detail;
 
+    let updatedMeals: FeedingTime[];
+
     if (index !== undefined && index >= 0) {
-      this.updateMeal(index, meal);
+      updatedMeals = this.sortMealsByTime(
+        this.draftMeals.map((m, i) => (i === index ? meal : m)),
+      );
     } else {
-      this.addMeal(meal);
+      updatedMeals = this.sortMealsByTime([...this.draftMeals, meal]);
     }
 
-    this.closeEditForm();
+    this.draftMeals = updatedMeals;
+    await this.mealState.saveMeals(updatedMeals);
+    this.dispatchEvent(new ScheduleClosedEvent());
+  }
+
+  private async handleDeleteFromEdit() {
+    if (this.editMeal?.index === undefined) return;
+    const updatedMeals = this.draftMeals.filter(
+      (_, i) => i !== this.editMeal!.index,
+    );
+    this.draftMeals = updatedMeals;
+    await this.mealState.saveMeals(updatedMeals);
+    this.dispatchEvent(new ScheduleClosedEvent());
   }
 
   private closeEditForm() {
@@ -170,6 +212,9 @@ export class ScheduleView extends LitElement {
   private renderMealForm() {
     if (this.editMeal === null) return '';
 
+    const isExisting =
+      this.editMeal.index !== undefined && this.editMeal.index >= 0;
+
     return html`
       <div>
         <meal-edit-dialog
@@ -180,28 +225,28 @@ export class ScheduleView extends LitElement {
           @save=${this.handleEditSave}
           @cancel=${this.closeEditForm}
         ></meal-edit-dialog>
+        <div class="edit-footer">
+          ${isExisting &&
+          hasProfileField(this.mealState.profile, ProfileField.DELETE)
+            ? html`
+                <button class="delete-link" @click=${this.handleDeleteFromEdit}>
+                  ${localize('common.delete')}
+                </button>
+              `
+            : html`<span></span>`}
+          <ha-button
+            @click=${() => {
+              const dialog =
+                this.shadowRoot?.querySelector<MealEditDialog>(
+                  'meal-edit-dialog',
+                );
+              dialog?.handleSave();
+            }}
+          >
+            ${localize('common.save')}
+          </ha-button>
+        </div>
       </div>
-      <ha-dialog-footer slot="footer">
-        <ha-button
-          slot="secondaryAction"
-          appearance="plain"
-          @click=${this.closeEditForm}
-        >
-          ${localize('common.back')}
-        </ha-button>
-        <ha-button
-          slot="primaryAction"
-          @click=${() => {
-            const dialog =
-              this.shadowRoot?.querySelector<MealEditDialog>(
-                'meal-edit-dialog',
-              );
-            dialog?.handleSave();
-          }}
-        >
-          ${localize('common.save')}
-        </ha-button>
-      </ha-dialog-footer>
     `;
   }
 

--- a/src/components/schedule-view.ts
+++ b/src/components/schedule-view.ts
@@ -183,12 +183,12 @@ export class ScheduleView extends LitElement {
         <ha-button
           slot="primaryAction"
           @click=${() => {
-        const dialog =
-          this.shadowRoot?.querySelector<MealEditDialog>(
-            'meal-edit-dialog',
-          );
-        dialog?.handleSave();
-      }}
+            const dialog =
+              this.shadowRoot?.querySelector<MealEditDialog>(
+                'meal-edit-dialog',
+              );
+            dialog?.handleSave();
+          }}
         >
           ${localize('common.save')}
         </ha-button>
@@ -237,9 +237,9 @@ export class ScheduleView extends LitElement {
       ></message-banner>
       <div class="schedule-cards">
         ${this.draftMeals.length === 0
-        ? this.renderEmptyState()
-        : this.draftMeals.map(
-          (meal, index) => html`
+          ? this.renderEmptyState()
+          : this.draftMeals.map(
+              (meal, index) => html`
                 <meal-card
                   .meal=${meal}
                   .index=${index}
@@ -248,7 +248,7 @@ export class ScheduleView extends LitElement {
                 >
                 </meal-card>
               `,
-        )}
+            )}
       </div>
       <ha-dialog-footer slot="footer">
         ${this.renderAddButton()}

--- a/src/components/schedule-view.ts
+++ b/src/components/schedule-view.ts
@@ -49,7 +49,7 @@ export class ScheduleView extends LitElement {
       }
     }, 0);
   }
-  
+
   private sortMealsByTime(meals: FeedingTime[]): FeedingTime[] {
     return [...meals].sort(
       (a, b) =>

--- a/src/components/schedule-view.ts
+++ b/src/components/schedule-view.ts
@@ -36,11 +36,20 @@ export class ScheduleView extends LitElement {
       this.syncMealsWithController();
     });
 
-    if (this.openAddOnLoad) {
-      this.handleOpenAdd();
-    }
+    // Use setTimeout to ensure properties are set before checking
+    setTimeout(() => {
+      if (this.openAddOnLoad) {
+        this.handleOpenAdd();
+      } else if (this.editMealIndex !== undefined) {
+        const meal = this.mealState.meals[this.editMealIndex];
+        if (meal) {
+          this.heading = localize('schedule_view.edit_feeding_time');
+          this.editMeal = { meal, index: this.editMealIndex };
+        }
+      }
+    }, 0);
   }
-
+  
   private sortMealsByTime(meals: FeedingTime[]): FeedingTime[] {
     return [...meals].sort(
       (a, b) =>

--- a/src/config-form.ts
+++ b/src/config-form.ts
@@ -22,17 +22,12 @@ export class MealPlanCardEditor extends LitElement {
   private _getAvailableServices() {
     const services: Array<{ value: string; label: string }> = [];
     if (!this.hass?.services) return services;
-
     for (const [domain, domainServices] of Object.entries(this.hass.services)) {
       for (const service of Object.keys(domainServices)) {
         const serviceId = `${domain}.${service}`;
-        services.push({
-          value: serviceId,
-          label: serviceId,
-        });
+        services.push({ value: serviceId, label: serviceId });
       }
     }
-
     return services.sort((a, b) => a.label.localeCompare(b.label));
   }
 
@@ -65,25 +60,17 @@ export class MealPlanCardEditor extends LitElement {
                 multiple: true,
                 mode: 'dropdown',
                 options: [
-                  {
-                    value: OverviewField.SCHEDULES,
-                    label: localize('overview.schedules'),
-                  },
-                  {
-                    value: OverviewField.ACTIVE,
-                    label: localize('overview.active'),
-                  },
-                  {
-                    value: OverviewField.TODAY,
-                    label: localize('overview.today'),
-                  },
-                  {
-                    value: OverviewField.AVG_WEEK,
-                    label: localize('overview.avg_week'),
-                  },
+                  { value: OverviewField.SCHEDULES, label: localize('overview.schedules') },
+                  { value: OverviewField.ACTIVE, label: localize('overview.active') },
+                  { value: OverviewField.TODAY, label: localize('overview.today') },
+                  { value: OverviewField.AVG_WEEK, label: localize('overview.avg_week') },
                 ],
               },
             },
+          },
+          {
+            name: 'show_schedules',
+            selector: { boolean: {} },
           },
         ],
       },
@@ -139,6 +126,7 @@ export class MealPlanCardEditor extends LitElement {
         ],
       });
     }
+
     if (this._config.transport_type === TransportType.MQTT) {
       schema.push({
         type: 'grid',
@@ -159,6 +147,7 @@ export class MealPlanCardEditor extends LitElement {
         ],
       });
     }
+
     if (this._config.transport_type === TransportType.TUYA_SERVICE) {
       schema.push({
         type: 'grid',
@@ -166,9 +155,7 @@ export class MealPlanCardEditor extends LitElement {
           {
             name: 'device_id',
             required: true,
-            selector: {
-              device: {},
-            },
+            selector: { device: {} },
           },
           {
             name: 'read_action',
@@ -193,19 +180,16 @@ export class MealPlanCardEditor extends LitElement {
         ],
       });
     }
+
     return schema;
   }
-  /*
-   * Checks if all required fields in the current config are filled.
-   */
+
   private _allRequiredFieldsFilled(): boolean {
     if (!this._config) return false;
     const schema = this._computeSchema();
     return this._checkRequiredFields(schema);
   }
-  /**
-   *  Recursively checks required fields in the schema.
-   */
+
   private _checkRequiredFields(schema: Record<string, unknown>[]): boolean {
     for (const field of schema) {
       if (field.schema && Array.isArray(field.schema)) {
@@ -222,6 +206,7 @@ export class MealPlanCardEditor extends LitElement {
     }
     return true;
   }
+
   private _valueChanged(ev: CustomEvent) {
     this._config = ev.detail.value;
     if (this._allRequiredFieldsFilled()) {
@@ -237,7 +222,6 @@ export class MealPlanCardEditor extends LitElement {
 
   render() {
     const isValid = this._allRequiredFieldsFilled();
-
     return html`
       ${!isValid
         ? html`<ha-alert alert-type="warning">
@@ -277,12 +261,15 @@ export class MealPlanCardEditor extends LitElement {
         return localize('config.read_action_label');
       case 'device_id':
         return localize('config.device_id_label');
+      case 'show_schedules':
+        return localize('config.show_schedules_label');
       case 'incomplete_configuration':
         return localize('config.incomplete_configuration');
       default:
         return undefined;
     }
   };
+
   private computeHelper = (schema: { name: string }) => {
     switch (schema.name) {
       case 'sensor':
@@ -297,6 +284,8 @@ export class MealPlanCardEditor extends LitElement {
         return localize('config.overview_fields_helper');
       case 'transport_type':
         return localize('config.transport_helper');
+      case 'show_schedules':
+        return localize('config.show_schedules_helper');
       default:
         return undefined;
     }

--- a/src/config-form.ts
+++ b/src/config-form.ts
@@ -60,10 +60,22 @@ export class MealPlanCardEditor extends LitElement {
                 multiple: true,
                 mode: 'dropdown',
                 options: [
-                  { value: OverviewField.SCHEDULES, label: localize('overview.schedules') },
-                  { value: OverviewField.ACTIVE, label: localize('overview.active') },
-                  { value: OverviewField.TODAY, label: localize('overview.today') },
-                  { value: OverviewField.AVG_WEEK, label: localize('overview.avg_week') },
+                  {
+                    value: OverviewField.SCHEDULES,
+                    label: localize('overview.schedules'),
+                  },
+                  {
+                    value: OverviewField.ACTIVE,
+                    label: localize('overview.active'),
+                  },
+                  {
+                    value: OverviewField.TODAY,
+                    label: localize('overview.today'),
+                  },
+                  {
+                    value: OverviewField.AVG_WEEK,
+                    label: localize('overview.avg_week'),
+                  },
                 ],
               },
             },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -69,7 +69,9 @@
     "write_action_label": "Write Action",
     "dp_code_label": "Data Point Code",
     "device_id_label": "Device ID",
-    "incomplete_configuration": "Incomplete Configuration"
+    "incomplete_configuration": "Incomplete Configuration",
+    "show_schedules_label": "Show schedules",
+    "show_schedules_helper": "Show the feeding schedule directly on the card without opening the manage dialog"
   },
   "overview": {
     "schedules": "Schedules",

--- a/src/locales/localize.ts
+++ b/src/locales/localize.ts
@@ -3,9 +3,10 @@ import sv from './sv.json';
 import ru from './ru.json';
 import es from './es.json';
 import cs from './cs.json';
+import nl from './nl.json';
 
 type Translation = Record<string, unknown>;
-const translations = { en, sv, ru, es, cs } satisfies Record<
+const translations = { en, sv, ru, es, cs, nl } satisfies Record<
   string,
   Translation
 >;

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -1,0 +1,82 @@
+{
+    "common": {
+        "back": "Terug",
+        "cancel": "Annuleren",
+        "save": "Opslaan",
+        "delete": "Verwijderen",
+        "close": "Sluiten",
+        "portion": "Portie",
+        "time": "Tijd",
+        "days": "Dagen",
+        "enabled": "Ingeschakeld",
+        "disabled": "Uitgeschakeld",
+        "every_day": "Elke dag",
+        "no_days": "Geen dagen",
+        "add_meal": "Maaltijd toevoegen"
+    },
+    "days": {
+        "short": {
+            "monday": "M",
+            "tuesday": "D",
+            "wednesday": "W",
+            "thursday": "D",
+            "friday": "V",
+            "saturday": "Z",
+            "sunday": "Z"
+        },
+        "full": {
+            "monday": "Maandag",
+            "tuesday": "Dinsdag",
+            "wednesday": "Woensdag",
+            "thursday": "Donderdag",
+            "friday": "Vrijdag",
+            "saturday": "Zaterdag",
+            "sunday": "Zondag"
+        }
+    },
+    "main": {
+        "manage_schedules": "Beheren",
+        "configuration_required": "Configuratie vereist",
+        "configuration_instructions": "Configureer een sensor en fabrikant in de kaartinstellingen."
+    },
+    "schedule_view": {
+        "manage_schedules": "Beheren",
+        "edit_feeding_time": "Voertijd bewerken",
+        "no_meals_scheduled": "Geen maaltijden gepland",
+        "click_add_meal_to_get_started": "Klik op 'Maaltijd toevoegen' om het eerste voerschema aan te maken",
+        "sensor_unavailable": "Entiteit niet beschikbaar",
+        "sensor_unavailable_message": "De geselecteerde sensor is niet beschikbaar. Je kunt geen wijzigingen opslaan totdat het apparaat bereikbaar is."
+    },
+    "meal_card": {
+        "edit_meal": "Maaltijd bewerken",
+        "confirm_delete": "Weet je zeker dat je deze maaltijd wilt verwijderen?"
+    },
+    "config": {
+        "portion_label": "Portiegrootte",
+        "portion_helper": "Gram per portie",
+        "sensor_label": "Maaltijdplan sensor",
+        "sensor_helper": "Selecteer de sensor of tekst-entiteit met de maaltijdplandata",
+        "manufacturer_label": "Voederprofiel",
+        "manufacturer_helper": "Selecteer de fabrikant en het model van de voerautomaat",
+        "title_label": "Titel",
+        "overview_fields_label": "Overzichtschips",
+        "overview_fields_helper": "Selecteer welke chips in de overzichtrij worden getoond",
+        "helper_label": "Hulpentiteit (optioneel)",
+        "helper_helper": "Deze input_text dient als reserveopslag voor je voerschema. Als de sensor niet beschikbaar is, herstelt de kaart het schema vanuit deze helper.",
+        "transport_label": "Transporttype",
+        "transport_helper": "Hoe data te schrijven: Sensor (via set_value service) of MQTT (publiceer naar zigbee2mqtt topic)",
+        "read_action_label": "Leesactie",
+        "write_action_label": "Schrijfactie",
+        "dp_code_label": "Datapuntcode",
+        "device_id_label": "Apparaat-ID",
+        "incomplete_configuration": "Onvolledige configuratie",
+        "show_schedules_label": "Toon schema",
+        "show_schedules_helper": "Toon het voerschema direct op de kaart zonder het beheerdialoogvenster te openen"
+    },
+    "overview": {
+        "schedules": "Schema's",
+        "active": "Actief",
+        "today": "Vandaag",
+        "avg_week": "Gem/Week"
+    }
+}

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -1,82 +1,82 @@
 {
-    "common": {
-        "back": "Terug",
-        "cancel": "Annuleren",
-        "save": "Opslaan",
-        "delete": "Verwijderen",
-        "close": "Sluiten",
-        "portion": "Portie",
-        "time": "Tijd",
-        "days": "Dagen",
-        "enabled": "Ingeschakeld",
-        "disabled": "Uitgeschakeld",
-        "every_day": "Elke dag",
-        "no_days": "Geen dagen",
-        "add_meal": "Maaltijd toevoegen"
+  "common": {
+    "back": "Terug",
+    "cancel": "Annuleren",
+    "save": "Opslaan",
+    "delete": "Verwijderen",
+    "close": "Sluiten",
+    "portion": "Portie",
+    "time": "Tijd",
+    "days": "Dagen",
+    "enabled": "Ingeschakeld",
+    "disabled": "Uitgeschakeld",
+    "every_day": "Elke dag",
+    "no_days": "Geen dagen",
+    "add_meal": "Maaltijd toevoegen"
+  },
+  "days": {
+    "short": {
+      "monday": "M",
+      "tuesday": "D",
+      "wednesday": "W",
+      "thursday": "D",
+      "friday": "V",
+      "saturday": "Z",
+      "sunday": "Z"
     },
-    "days": {
-        "short": {
-            "monday": "M",
-            "tuesday": "D",
-            "wednesday": "W",
-            "thursday": "D",
-            "friday": "V",
-            "saturday": "Z",
-            "sunday": "Z"
-        },
-        "full": {
-            "monday": "Maandag",
-            "tuesday": "Dinsdag",
-            "wednesday": "Woensdag",
-            "thursday": "Donderdag",
-            "friday": "Vrijdag",
-            "saturday": "Zaterdag",
-            "sunday": "Zondag"
-        }
-    },
-    "main": {
-        "manage_schedules": "Beheren",
-        "configuration_required": "Configuratie vereist",
-        "configuration_instructions": "Configureer een sensor en fabrikant in de kaartinstellingen."
-    },
-    "schedule_view": {
-        "manage_schedules": "Beheren",
-        "edit_feeding_time": "Voertijd bewerken",
-        "no_meals_scheduled": "Geen maaltijden gepland",
-        "click_add_meal_to_get_started": "Klik op 'Maaltijd toevoegen' om het eerste voerschema aan te maken",
-        "sensor_unavailable": "Entiteit niet beschikbaar",
-        "sensor_unavailable_message": "De geselecteerde sensor is niet beschikbaar. Je kunt geen wijzigingen opslaan totdat het apparaat bereikbaar is."
-    },
-    "meal_card": {
-        "edit_meal": "Maaltijd bewerken",
-        "confirm_delete": "Weet je zeker dat je deze maaltijd wilt verwijderen?"
-    },
-    "config": {
-        "portion_label": "Portiegrootte",
-        "portion_helper": "Gram per portie",
-        "sensor_label": "Maaltijdplan sensor",
-        "sensor_helper": "Selecteer de sensor of tekst-entiteit met de maaltijdplandata",
-        "manufacturer_label": "Voederprofiel",
-        "manufacturer_helper": "Selecteer de fabrikant en het model van de voerautomaat",
-        "title_label": "Titel",
-        "overview_fields_label": "Overzichtschips",
-        "overview_fields_helper": "Selecteer welke chips in de overzichtrij worden getoond",
-        "helper_label": "Hulpentiteit (optioneel)",
-        "helper_helper": "Deze input_text dient als reserveopslag voor je voerschema. Als de sensor niet beschikbaar is, herstelt de kaart het schema vanuit deze helper.",
-        "transport_label": "Transporttype",
-        "transport_helper": "Hoe data te schrijven: Sensor (via set_value service) of MQTT (publiceer naar zigbee2mqtt topic)",
-        "read_action_label": "Leesactie",
-        "write_action_label": "Schrijfactie",
-        "dp_code_label": "Datapuntcode",
-        "device_id_label": "Apparaat-ID",
-        "incomplete_configuration": "Onvolledige configuratie",
-        "show_schedules_label": "Toon schema",
-        "show_schedules_helper": "Toon het voerschema direct op de kaart zonder het beheerdialoogvenster te openen"
-    },
-    "overview": {
-        "schedules": "Schema's",
-        "active": "Actief",
-        "today": "Vandaag",
-        "avg_week": "Gem/Week"
+    "full": {
+      "monday": "Maandag",
+      "tuesday": "Dinsdag",
+      "wednesday": "Woensdag",
+      "thursday": "Donderdag",
+      "friday": "Vrijdag",
+      "saturday": "Zaterdag",
+      "sunday": "Zondag"
     }
+  },
+  "main": {
+    "manage_schedules": "Beheren",
+    "configuration_required": "Configuratie vereist",
+    "configuration_instructions": "Configureer een sensor en fabrikant in de kaartinstellingen."
+  },
+  "schedule_view": {
+    "manage_schedules": "Beheren",
+    "edit_feeding_time": "Voertijd bewerken",
+    "no_meals_scheduled": "Geen maaltijden gepland",
+    "click_add_meal_to_get_started": "Klik op 'Maaltijd toevoegen' om het eerste voerschema aan te maken",
+    "sensor_unavailable": "Entiteit niet beschikbaar",
+    "sensor_unavailable_message": "De geselecteerde sensor is niet beschikbaar. Je kunt geen wijzigingen opslaan totdat het apparaat bereikbaar is."
+  },
+  "meal_card": {
+    "edit_meal": "Maaltijd bewerken",
+    "confirm_delete": "Weet je zeker dat je deze maaltijd wilt verwijderen?"
+  },
+  "config": {
+    "portion_label": "Portiegrootte",
+    "portion_helper": "Gram per portie",
+    "sensor_label": "Maaltijdplan sensor",
+    "sensor_helper": "Selecteer de sensor of tekst-entiteit met de maaltijdplandata",
+    "manufacturer_label": "Voederprofiel",
+    "manufacturer_helper": "Selecteer de fabrikant en het model van de voerautomaat",
+    "title_label": "Titel",
+    "overview_fields_label": "Overzichtschips",
+    "overview_fields_helper": "Selecteer welke chips in de overzichtrij worden getoond",
+    "helper_label": "Hulpentiteit (optioneel)",
+    "helper_helper": "Deze input_text dient als reserveopslag voor je voerschema. Als de sensor niet beschikbaar is, herstelt de kaart het schema vanuit deze helper.",
+    "transport_label": "Transporttype",
+    "transport_helper": "Hoe data te schrijven: Sensor (via set_value service) of MQTT (publiceer naar zigbee2mqtt topic)",
+    "read_action_label": "Leesactie",
+    "write_action_label": "Schrijfactie",
+    "dp_code_label": "Datapuntcode",
+    "device_id_label": "Apparaat-ID",
+    "incomplete_configuration": "Onvolledige configuratie",
+    "show_schedules_label": "Toon schema",
+    "show_schedules_helper": "Toon het voerschema direct op de kaart zonder het beheerdialoogvenster te openen"
+  },
+  "overview": {
+    "schedules": "Schema's",
+    "active": "Actief",
+    "today": "Vandaag",
+    "avg_week": "Gem/Week"
+  }
 }

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -12,7 +12,7 @@
     "disabled": "Uitgeschakeld",
     "every_day": "Elke dag",
     "no_days": "Geen dagen",
-    "add_meal": "Maaltijd toevoegen"
+    "add_meal": "+ Toevoegen"
   },
   "days": {
     "short": {
@@ -41,15 +41,15 @@
   },
   "schedule_view": {
     "manage_schedules": "Beheren",
-    "edit_feeding_time": "Voertijd bewerken",
-    "no_meals_scheduled": "Geen maaltijden gepland",
-    "click_add_meal_to_get_started": "Klik op 'Maaltijd toevoegen' om het eerste voerschema aan te maken",
+    "edit_feeding_time": "Tijd bewerken",
+    "no_meals_scheduled": "Geen tijden gepland",
+    "click_add_meal_to_get_started": "Klik op '+ Toevoegen' om het eerste voerschema aan te maken",
     "sensor_unavailable": "Entiteit niet beschikbaar",
     "sensor_unavailable_message": "De geselecteerde sensor is niet beschikbaar. Je kunt geen wijzigingen opslaan totdat het apparaat bereikbaar is."
   },
   "meal_card": {
-    "edit_meal": "Maaltijd bewerken",
-    "confirm_delete": "Weet je zeker dat je deze maaltijd wilt verwijderen?"
+    "edit_meal": "Bewerken",
+    "confirm_delete": "Weet je zeker dat je deze tijd wilt verwijderen?"
   },
   "config": {
     "portion_label": "Portiegrootte",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -69,7 +69,9 @@
     "write_action_label": "Skriva åtgärd",
     "dp_code_label": "Datapunktkod",
     "device_id_label": "Enhets-ID",
-    "incomplete_configuration": "Ofullständig konfiguration"
+    "incomplete_configuration": "Ofullständig konfiguration",
+    "show_schedules_label": "Visa schema",
+    "show_schedules_helper": "Visa matningsschemat direkt på kortet utan att öppna hanteringsdialogen"
   },
   "overview": {
     "schedules": "Scheman",

--- a/src/main.ts
+++ b/src/main.ts
@@ -124,9 +124,9 @@ export class MealPlanCard extends LitElement {
         ></meal-overview>
         <div class="inline-schedules">
           ${this.mealState.meals.length === 0
-          ? html`<p>${localize('schedule_view.no_meals_scheduled')}</p>`
-          : this.mealState.meals.map(
-            (meal, index) => html`
+            ? html`<p>${localize('schedule_view.no_meals_scheduled')}</p>`
+            : this.mealState.meals.map(
+                (meal, index) => html`
                   <meal-card
                     .meal=${meal}
                     .index=${index}
@@ -134,17 +134,17 @@ export class MealPlanCard extends LitElement {
                     .onMealAction=${this._handleMealAction.bind(this)}
                   ></meal-card>
                 `,
-          )}
+              )}
         </div>
         <div class="card-actions">
           <ha-button
             appearance="plain"
             variant="brand"
             @click=${() => {
-          this._openAddOnLoad = true;
-          this._editMealIndex = undefined;
-          this._dialogOpen = true;
-        }}
+              this._openAddOnLoad = true;
+              this._editMealIndex = undefined;
+              this._dialogOpen = true;
+            }}
           >
             ${localize('common.add_meal')}
           </ha-button>
@@ -189,10 +189,10 @@ export class MealPlanCard extends LitElement {
         .openAddOnLoad=${this._openAddOnLoad}
         .editMealIndex=${this._editMealIndex}
         @schedule-closed=${() => {
-        this._dialogOpen = false;
-        this._openAddOnLoad = false;
-        this._editMealIndex = undefined;
-      }}
+          this._dialogOpen = false;
+          this._openAddOnLoad = false;
+          this._editMealIndex = undefined;
+        }}
       ></schedule-view>
     `;
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,8 +5,9 @@ import { MealStateController } from './mealStateController';
 import type { HomeAssistant, MealPlanCardConfig } from './types';
 import { OverviewField, TransportType } from './types';
 import { getProfileWithTransformer } from './profiles/profiles';
-import './components/overview';
-import './components/schedule-view';
+import './components/overview.js';
+import './components/schedule-view.js';
+import './components/meal-card.js';
 import { log } from './logger';
 import { getVersionString } from './version';
 import './config-form.js';
@@ -17,22 +18,24 @@ export class MealPlanCard extends LitElement {
   @property({ type: Object }) config!: MealPlanCardConfig;
   @state() public mealState?: MealStateController;
   @state() private _dialogOpen = false;
+  @state() private _openAddOnLoad = false;
 
   static get styles() {
     return css`
-      :host,
-      ha-card {
-        display: block;
-        height: 100%;
-        overflow: hidden;
-      }
+    :host,
+    ha-card {
+      display: block;
+      height: 100%;
+      overflow: hidden;
+    }
+    .inline-schedules {
+      padding: 0 16px 8px 16px;
+    }
     `;
   }
-
   setConfig(config: MealPlanCardConfig) {
     this.config = config;
 
-    // Initialize controller if we have all prerequisites
     if (this.hass && this.config.manufacturer) {
       const profile = getProfileWithTransformer(this.config.manufacturer);
 
@@ -52,7 +55,6 @@ export class MealPlanCard extends LitElement {
 
     await setLanguage(this.hass?.language);
 
-    // Initialize meal state controller (hass is now available)
     if (this.config.manufacturer) {
       const profile = getProfileWithTransformer(this.config.manufacturer);
 
@@ -91,6 +93,40 @@ export class MealPlanCard extends LitElement {
       return this.renderConfigurationRequired();
     }
 
+    if (this.config.show_schedules) {
+      return html`
+        <meal-overview
+          .meals=${this.mealState.meals}
+          .portions=${this.config?.portions}
+          .overviewFields=${this.config.overview_fields}
+        ></meal-overview>
+        <div class="inline-schedules">
+          ${this.mealState.meals.length === 0
+          ? html`<p>${localize('schedule_view.no_meals_scheduled')}</p>`
+          : this.mealState.meals.map(
+            (meal, index) => html`
+                  <meal-card
+                    .meal=${meal}
+                    .index=${index}
+                    .profile=${this.mealState!.profile}
+                  ></meal-card>
+                `,
+          )}
+        <div class="card-actions">
+          <ha-button
+            appearance="plain"
+            variant="brand"
+            @click=${() => {
+                  this._openAddOnLoad = true;
+                  this._dialogOpen = true;
+                }}
+          >
+            ${localize('common.add_meal')}
+          </ha-button>
+        </div>
+      `;
+    }
+
     return html`
       <meal-overview
         .meals=${this.mealState.meals}
@@ -125,16 +161,15 @@ export class MealPlanCard extends LitElement {
       <schedule-view
         .mealState=${this.mealState}
         .hass=${this.hass}
+        .openAddOnLoad=${this._openAddOnLoad}
         @schedule-closed=${() => {
-          this._dialogOpen = false;
-        }}
+        this._dialogOpen = false;
+        this._openAddOnLoad = false;
+      }}
       ></schedule-view>
     `;
   }
 
-  //static getConfigForm(): ReturnType<typeof generateConfigFormSchema> {
-  //  return generateConfigFormSchema();
-  ///}
   static getConfigElement() {
     return document.createElement('mealplan-card-editor');
   }
@@ -150,6 +185,7 @@ export class MealPlanCard extends LitElement {
         OverviewField.AVG_WEEK,
       ],
       transport_type: TransportType.SENSOR,
+      show_schedules: false,
     } as MealPlanCardConfig;
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@
 import { customElement, property, state } from 'lit/decorators.js';
 import { localize, setLanguage } from './locales/localize';
 import { MealStateController } from './mealStateController';
-import type { HomeAssistant, MealPlanCardConfig } from './types';
+import type { HomeAssistant, MealPlanCardConfig, FeedingTime } from './types';
 import { OverviewField, TransportType } from './types';
 import { getProfileWithTransformer } from './profiles/profiles';
 import './components/overview.js';
@@ -19,20 +19,22 @@ export class MealPlanCard extends LitElement {
   @state() public mealState?: MealStateController;
   @state() private _dialogOpen = false;
   @state() private _openAddOnLoad = false;
+  @state() private _editMealIndex: number | undefined = undefined;
 
   static get styles() {
     return css`
-    :host,
-    ha-card {
-      display: block;
-      height: 100%;
-      overflow: hidden;
-    }
-    .inline-schedules {
-      padding: 0 16px 8px 16px;
-    }
+      :host,
+      ha-card {
+        display: block;
+        height: 100%;
+        overflow: hidden;
+      }
+      .inline-schedules {
+        padding: 0 16px 8px 16px;
+      }
     `;
   }
+
   setConfig(config: MealPlanCardConfig) {
     this.config = config;
 
@@ -88,6 +90,26 @@ export class MealPlanCard extends LitElement {
     `;
   }
 
+  private _handleMealAction(
+    action: string,
+    index: number,
+    meal: FeedingTime,
+  ): void {
+    if (action === 'edit') {
+      this._editMealIndex = index;
+      this._openAddOnLoad = false;
+      this._dialogOpen = true;
+    } else if (action === 'delete') {
+      const updated = this.mealState!.meals.filter((_, i) => i !== index);
+      this.mealState!.saveMeals(updated);
+    } else if (action === 'update') {
+      const updated = this.mealState!.meals.map((m, i) =>
+        i === index ? meal : m,
+      );
+      this.mealState!.saveMeals(updated);
+    }
+  }
+
   private renderContent() {
     if (!this.mealState) {
       return this.renderConfigurationRequired();
@@ -109,17 +131,20 @@ export class MealPlanCard extends LitElement {
                     .meal=${meal}
                     .index=${index}
                     .profile=${this.mealState!.profile}
+                    .onMealAction=${this._handleMealAction.bind(this)}
                   ></meal-card>
                 `,
           )}
+        </div>
         <div class="card-actions">
           <ha-button
             appearance="plain"
             variant="brand"
             @click=${() => {
-                  this._openAddOnLoad = true;
-                  this._dialogOpen = true;
-                }}
+          this._openAddOnLoad = true;
+          this._editMealIndex = undefined;
+          this._dialogOpen = true;
+        }}
           >
             ${localize('common.add_meal')}
           </ha-button>
@@ -162,9 +187,11 @@ export class MealPlanCard extends LitElement {
         .mealState=${this.mealState}
         .hass=${this.hass}
         .openAddOnLoad=${this._openAddOnLoad}
+        .editMealIndex=${this._editMealIndex}
         @schedule-closed=${() => {
         this._dialogOpen = false;
         this._openAddOnLoad = false;
+        this._editMealIndex = undefined;
       }}
       ></schedule-view>
     `;

--- a/src/main.ts
+++ b/src/main.ts
@@ -199,6 +199,11 @@ export class MealPlanCard extends LitElement {
           this._openAddOnLoad = false;
           this._editMealIndex = undefined;
         }}
+        @closed=${() => {
+          this._dialogOpen = false;
+          this._openAddOnLoad = false;
+          this._editMealIndex = undefined;
+        }}
       ></schedule-view>
     `;
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,9 @@ export class MealPlanCard extends LitElement {
       .inline-schedules {
         padding: 0 16px 8px 16px;
       }
+      .inline-schedules.no-overview {
+        padding-top: 8px;
+      }
     `;
   }
 
@@ -116,13 +119,16 @@ export class MealPlanCard extends LitElement {
     }
 
     if (this.config.show_schedules) {
+      const hasOverview =
+        this.config.overview_fields && this.config.overview_fields.length > 0;
+
       return html`
         <meal-overview
           .meals=${this.mealState.meals}
           .portions=${this.config?.portions}
           .overviewFields=${this.config.overview_fields}
         ></meal-overview>
-        <div class="inline-schedules">
+        <div class="inline-schedules ${!hasOverview ? 'no-overview' : ''}">
           ${this.mealState.meals.length === 0
             ? html`<p>${localize('schedule_view.no_meals_scheduled')}</p>`
             : this.mealState.meals.map(

--- a/src/mealStateController.ts
+++ b/src/mealStateController.ts
@@ -2,7 +2,6 @@
  * Reactive controller for managing meal plan state
  * Implements Lit's ReactiveController pattern - calls host.requestUpdate() when state changes
  */
-
 import type { ReactiveController, ReactiveControllerHost } from 'lit';
 import { FeedingTime, DeviceProfile } from './types';
 import type { HasGetter, MealPlanCardConfig, StorageAdapter } from './types';
@@ -13,6 +12,7 @@ import { areMealsEqual } from './utils';
 export class MealStateController implements ReactiveController {
   private _meals: FeedingTime[] = [];
   private subscribers = new Set<() => void>();
+  private _saving = false;
 
   hass: HasGetter;
   profile: DeviceProfile;
@@ -41,7 +41,6 @@ export class MealStateController implements ReactiveController {
     this.config = config;
     this.adapter = createStorageAdapter(hass, config, profile);
 
-    // Load initial data after construction
     if (this.hass()) {
       this.updateFromHass().catch((error) => {
         log.error('Failed to load initial data:', error);
@@ -53,37 +52,32 @@ export class MealStateController implements ReactiveController {
     }
   }
 
-  hostConnected(): void {}
+  hostConnected(): void { }
 
   hostDisconnected(): void {
     this.subscribers.clear();
   }
 
-  /**
-   * Subscribe to meals changes
-   */
   subscribe(callback: () => void): () => void {
     this.subscribers.add(callback);
     return () => this.subscribers.delete(callback);
   }
 
-  /**
-   * Notify all subscribers of changes
-   */
   private notifySubscribers(): void {
     this.host.requestUpdate();
     this.subscribers.forEach((callback) => callback());
   }
 
-  /**
-   * Update from Home Assistant - read and decode from storage adapter
-   */
   async updateFromHass(allowUpdate: boolean = true): Promise<void> {
+    if (this._saving) {
+      log.debug('Skipping updateFromHass - save in progress');
+      return;
+    }
+
     const decodedMeals = await this.adapter.read();
 
     if (allowUpdate) {
       const newMeals = decodedMeals ? [...decodedMeals] : [];
-      // Only update if meals have actually changed
       if (!areMealsEqual(decodedMeals, this.meals)) {
         this.meals = newMeals;
       } else {
@@ -92,24 +86,23 @@ export class MealStateController implements ReactiveController {
     }
   }
 
-  /**
-   * Save meals to storage via adapter, then update local state
-   */
   async saveMeals(meals: FeedingTime[]): Promise<void> {
+    this._saving = true;
     await this.adapter.write(meals);
     this.meals = [...meals];
+    setTimeout(() => {
+      this._saving = false;
+    }, 5000);
   }
 
   public async isDataAvailable(): Promise<boolean> {
     try {
       const available = await this.adapter.isDataAvailable();
-
       if (!available) {
         log.warn(
           '[MealStateController] Data not available - adapter returned empty value',
         );
       }
-
       return available;
     } catch (error) {
       log.warn(

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,6 +71,7 @@ export interface CardConfig {
   manufacturer?: string;
   model?: string;
   transport_type: TransportType;
+  show_schedules?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Changes

### UX improvements
- Clicking a meal row opens the edit dialog directly (no expand/collapse needed)
- Delete button moved to edit dialog footer, left-aligned in red
- No confirmation popup - avoids Firefox issues with browser confirm()
- Save and delete close the dialog immediately

### Bug fixes
- Fixed race condition in mealStateController where HA state updates
  could overwrite freshly saved meals (_saving flag with 5s timeout)
- Fixed edit dialog not opening directly when clicking edit from inline view

### Language
- Some improvements for Dutch language

### Technical
- Removed expand/collapse state from meal-card (simplified component)
- Custom footer layout for edit dialog using native button element
- Edit footer uses CSS divider and space-between layout

### Backwards compatible
- meal-card still works in schedule-view manage dialog
- No config changes required

<img width="450" height="424" alt="afbeelding" src="https://github.com/user-attachments/assets/aaad0401-b67d-4e65-b3c1-0dea2bcc2d83" />
<img width="857" height="401" alt="afbeelding" src="https://github.com/user-attachments/assets/7c37fd0a-f274-4014-87d7-54291e1b639c" />
